### PR TITLE
[V5] Fix overriden item label with groupBy options

### DIFF
--- a/src/lib/Select.svelte
+++ b/src/lib/Select.svelte
@@ -45,7 +45,7 @@
     export let createGroupHeaderItem = (groupValue, item) => {
         return {
             value: groupValue,
-            label: groupValue,
+            [label]: groupValue,
         };
     };
 


### PR DESCRIPTION
Fix: https://github.com/rob-balfre/svelte-select/issues/484